### PR TITLE
Add SIM API wrapper with CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Usage-Report
+# Usage Report
+
+Utilities to fetch information from the LRZ SIM API.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Command line usage
+
+```bash
+usage-report <user_id> [--netrc-file PATH]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "usage-report"
+version = "0.1.0"
+description = "Utilities to fetch usage information from LRZ SIM API"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [
+    {name = "Unknown", email = "unknown@example.com"}
+]
+dependencies = []
+
+[project.scripts]
+usage-report = "usage_report.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["tests*"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from unittest import mock
+
+import pytest
+
+from usage_report.api import SimAPI, SimAPIError
+
+
+class DummyResponse:
+    def __init__(self, status: int, data: bytes):
+        self.status = status
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_fetch_user_success():
+    api = SimAPI()
+    dummy = DummyResponse(200, b'{"kennung": "testuser"}')
+    with mock.patch.object(api, "_get_auth", return_value=("u", "p")):
+        with mock.patch("urllib.request.urlopen", return_value=dummy):
+            data = api.fetch_user("testuser")
+    assert data == {"kennung": "testuser"}
+
+
+def test_fetch_user_failure():
+    api = SimAPI()
+    dummy = DummyResponse(404, b'Not found')
+    with mock.patch.object(api, "_get_auth", return_value=("u", "p")):
+        with mock.patch("urllib.request.urlopen", return_value=dummy):
+            with pytest.raises(SimAPIError):
+                api.fetch_user("baduser")

--- a/usage_report/__init__.py
+++ b/usage_report/__init__.py
@@ -1,0 +1,6 @@
+"""Usage Report library."""
+
+from .api import SimAPI, SimAPIError
+
+__all__ = ["SimAPI", "SimAPIError"]
+__version__ = "0.1.0"

--- a/usage_report/api.py
+++ b/usage_report/api.py
@@ -1,0 +1,59 @@
+"""API wrapper for LRZ SIM API."""
+from __future__ import annotations
+
+import json
+import netrc
+import base64
+from pathlib import Path
+from typing import Any
+
+from urllib import request, error
+
+
+class SimAPIError(Exception):
+    """Custom exception for API errors."""
+
+
+class SimAPI:
+    """Wrapper around the LRZ SIM API."""
+
+    BASE_URL = "https://simapi.sim.lrz.de/user/"
+
+    def __init__(self, netrc_file: str | Path | None = None) -> None:
+        self.netrc_file = Path(netrc_file) if netrc_file else Path.home() / ".netrc"
+
+    def _get_auth(self) -> tuple[str, str]:
+        try:
+            auths = netrc.netrc(str(self.netrc_file))
+            login, _, password = auths.authenticators("simapi.sim.lrz.de")
+            if not (login and password):
+                raise SimAPIError("Incomplete credentials in netrc file")
+            return login, password
+        except (FileNotFoundError, netrc.NetrcParseError) as err:
+            raise SimAPIError(f"Failed to read netrc file: {err}") from err
+
+    def fetch_user(self, user_id: str) -> dict[str, Any]:
+        """Fetch user information for *user_id*.
+
+        Parameters
+        ----------
+        user_id:
+            The LRZ user identifier to query.
+        """
+        login, password = self._get_auth()
+        url = self.BASE_URL + user_id
+        headers = {"Accept": "application/json"}
+        credentials = f"{login}:{password}".encode()
+        headers["Authorization"] = "Basic " + base64.b64encode(credentials).decode()
+        req = request.Request(url, headers=headers)
+        try:
+            with request.urlopen(req) as resp:
+                if resp.status != 200:
+                    raise SimAPIError(f"API request failed with status {resp.status}: {resp.read().decode()}")
+                data = resp.read().decode()
+        except error.URLError as err:
+            raise SimAPIError(f"Failed to contact API: {err}") from err
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError as err:
+            raise SimAPIError("Failed to decode JSON response") from err

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -1,0 +1,35 @@
+"""Command line interface for usage-report."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pprint import pprint
+
+from .api import SimAPI, SimAPIError
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch user information from LRZ SIM API")
+    parser.add_argument("user_id", help="LRZ user identifier")
+    parser.add_argument(
+        "--netrc-file",
+        dest="netrc_file",
+        help="Custom path to .netrc file for authentication",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    api = SimAPI(netrc_file=args.netrc_file)
+    try:
+        data = api.fetch_user(args.user_id)
+    except SimAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    pprint(data)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- create Python package layout with `pyproject.toml`
- implement `SimAPI` to query LRZ SIM API using `urllib`
- provide CLI entry point `usage-report` with argparse
- add unit tests for the API wrapper
- update README with installation and usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd911ca1483258c7411998502ecf8