### PR TITLE
Fix parsing of nested API data

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,20 +8,27 @@ from usage_report.report import create_report, _pick_email, write_report_csv
 
 def test_pick_email_preferred():
     data = {
-        "first_name": "Max",
-        "last_name": "Mustermann",
-        "emails": ["max.mustermann@example.com", "other@example.com"],
+        "vorname": "Max",
+        "nachname": "Mustermann",
+        "emailadressen": [
+            {"adresse": "max.mustermann@example.com"},
+            {"adresse": "other@example.com"},
+        ],
     }
     assert _pick_email(data) == "max.mustermann@example.com"
 
 
 def test_create_report(tmp_path):
     user_info = {
-        "first_name": "Max",
-        "last_name": "Mustermann",
         "kennung": "mm123",
         "projekt": "proj",
-        "emails": ["max.mustermann@example.com"],
+        "daten": {
+            "vorname": "Max",
+            "nachname": "Mustermann",
+            "emailadressen": [
+                {"adresse": "max.mustermann@example.com"}
+            ],
+        },
     }
     usage = {"cpu_hours": 1.0, "gpu_hours": 0.5, "ram_gb_hours": 2.0}
 

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -8,25 +8,58 @@ from .api import SimAPI
 from .slurm import fetch_usage
 
 
+def _normalize_user_data(data: dict[str, object]) -> dict[str, object]:
+    """Return *data* with nested "daten" fields merged at the top level."""
+    if not isinstance(data, dict):
+        return data
+    result = data.copy()
+    details = result.get("daten")
+    if isinstance(details, dict):
+        for key, value in details.items():
+            result.setdefault(key, value)
+        if "emailadressen" in details and "emails" not in result:
+            result["emails"] = details["emailadressen"]
+    return result
+
+
 def _pick_email(data: dict[str, object]) -> str:
     """Return the best email from *data*.
 
     Prefers an address matching ``first.last@`` if available.
     """
-    first = (data.get("first_name") or data.get("firstname") or data.get("vorname"))
-    last = (data.get("last_name") or data.get("lastname") or data.get("nachname"))
+    first = (
+        data.get("first_name")
+        or data.get("firstname")
+        or data.get("vorname")
+    )
+    last = (
+        data.get("last_name")
+        or data.get("lastname")
+        or data.get("nachname")
+    )
     preferred = f"{first}.{last}".lower() if first and last else None
-    emails = data.get("emails") or data.get("email") or []
+    emails = (
+        data.get("emails")
+        or data.get("emailadressen")
+        or data.get("email")
+        or []
+    )
     if isinstance(emails, (str, dict)):
         emails = [emails]
     for item in emails:
-        addr = item.get("address") if isinstance(item, dict) else item
+        if isinstance(item, dict):
+            addr = item.get("address") or item.get("adresse")
+        else:
+            addr = item
         if not isinstance(addr, str):
             continue
         if preferred and addr.lower().startswith(preferred):
             return addr
     for item in emails:
-        addr = item.get("address") if isinstance(item, dict) else item
+        if isinstance(item, dict):
+            addr = item.get("address") or item.get("adresse")
+        else:
+            addr = item
         if isinstance(addr, str):
             return addr
     return ""
@@ -35,12 +68,16 @@ def _pick_email(data: dict[str, object]) -> str:
 def create_report(user_id: str, start: str, end: str | None = None, *, netrc_file: str | Path | None = None) -> dict[str, object]:
     """Return a combined report dictionary for *user_id*."""
     api = SimAPI(netrc_file=netrc_file)
-    user_data = api.fetch_user(user_id)
+    user_data = _normalize_user_data(api.fetch_user(user_id))
     usage = fetch_usage(user_id, start, end)
 
     report = {
-        "first_name": user_data.get("first_name"),
-        "last_name": user_data.get("last_name"),
+        "first_name": user_data.get("first_name")
+        or user_data.get("firstname")
+        or user_data.get("vorname"),
+        "last_name": user_data.get("last_name")
+        or user_data.get("lastname")
+        or user_data.get("nachname"),
         "email": _pick_email(user_data),
         "kennung": user_data.get("kennung"),
         "projekt": user_data.get("projekt"),


### PR DESCRIPTION
## Summary
- normalize API responses that contain nested data
- support `emailadressen` field when picking an email
- update combined report generation to handle new format
- adapt report tests for nested structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686270d07af88325954249da1303e141