### PR TITLE
Add timestamped append mode for report CSV

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -38,7 +38,17 @@ def test_create_report(tmp_path):
         with mock.patch("usage_report.report.fetch_usage", return_value=usage):
             report = create_report("mm123", "2025-01-01")
     assert report["email"] == "max.mustermann@example.com"
-    csv_path = write_report_csv(report, tmp_path, "out.csv")
+    csv_path = write_report_csv(report, tmp_path, "out.csv", start="2025-01-01")
     assert csv_path.exists()
     content = csv_path.read_text()
     assert "first_name,last_name" in content
+
+
+def test_write_report_csv_append(tmp_path):
+    row1 = {"first_name": "A", "last_name": "B"}
+    csv_path = write_report_csv(row1, tmp_path, "out.csv", start="2025-01-01")
+    row2 = {"first_name": "C", "last_name": "D"}
+    csv_path = write_report_csv(row2, tmp_path, "out.csv", start="2025-02-01")
+    lines = csv_path.read_text().splitlines()
+    assert len(lines) == 3
+    assert "timestamp" in lines[0]

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -72,7 +72,13 @@ def main(argv: list[str] | None = None) -> int:
         except SimAPIError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
-        output_path = write_report_csv(report, "output", f"{args.user_id}.csv")
+        output_path = write_report_csv(
+            report,
+            "output",
+            f"{args.user_id}.csv",
+            start=args.start,
+            end=args.end,
+        )
         pprint(report)
         print(f"Report written to {output_path}")
     return 0

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import csv
+from datetime import datetime
 
 from .api import SimAPI
 from .slurm import fetch_usage
@@ -86,15 +87,41 @@ def create_report(user_id: str, start: str, end: str | None = None, *, netrc_fil
     return report
 
 
-def write_report_csv(report: dict[str, object], output_dir: str | Path, filename: str) -> Path:
-    """Write *report* to ``output_dir/filename`` and return the path."""
+def write_report_csv(
+    report: dict[str, object],
+    output_dir: str | Path,
+    filename: str,
+    *,
+    start: str | None = None,
+    end: str | None = None,
+) -> Path:
+    """Write *report* to ``output_dir/filename`` and return the path.
+
+    If the file already exists, the row is appended.  A ``timestamp`` as well
+    as ``period_start`` and ``period_end`` columns are added automatically.
+    """
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / filename
-    with out_path.open("w", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=list(report.keys()))
-        writer.writeheader()
-        writer.writerow(report)
+
+    row = report.copy()
+    row["timestamp"] = datetime.now().isoformat(timespec="seconds")
+    row["period_start"] = start
+    row["period_end"] = end or ""
+
+    if out_path.exists():
+        with out_path.open("r", newline="") as fh:
+            reader = csv.DictReader(fh)
+            fieldnames = reader.fieldnames or list(row.keys())
+        with out_path.open("a", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writerow({f: row.get(f, "") for f in fieldnames})
+    else:
+        fieldnames = list(row.keys())
+        with out_path.open("w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerow(row)
     return out_path
 
 


### PR DESCRIPTION
## Summary
- extend `write_report_csv` to append if the file exists
- add timestamp and period information to each row
- pass start/end arguments from CLI
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686274021ecc832581f568b47459bb20