### PR TITLE
Improve CLI output with period

### DIFF
--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -79,7 +79,12 @@ def main(argv: list[str] | None = None) -> int:
             start=args.start,
             end=args.end,
         )
-        pprint(report)
+
+        report_with_period = report.copy()
+        report_with_period["period_start"] = args.start
+        report_with_period["period_end"] = args.end
+
+        pprint(report_with_period)
         print(f"Report written to {output_path}")
     return 0
 


### PR DESCRIPTION
## Summary
- show period_start and period_end when printing reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862755271948325b893cad3f6ecf13c