### PR TITLE
Add user group detection for AI-c projects

### DIFF
--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from unittest import mock
+
+from usage_report.groups import list_user_groups
+
+
+def test_list_user_groups():
+    sample_output = "uid=1000(user) gid=1000(user) groups=1000(user),27(sudo),111(test-ai-c)\n"
+    mocked_proc = mock.Mock(stdout=sample_output)
+    with mock.patch("subprocess.run", return_value=mocked_proc):
+        groups = list_user_groups("user")
+    assert groups == ["user", "sudo", "test-ai-c"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -36,12 +36,14 @@ def test_create_report(tmp_path):
         api_instance = MockAPI.return_value
         api_instance.fetch_user.return_value = user_info
         with mock.patch("usage_report.report.fetch_usage", return_value=usage):
-            report = create_report("mm123", "2025-01-01")
+            with mock.patch("usage_report.report.list_user_groups", return_value=["users", "project-ai-c", "other"]):
+                report = create_report("mm123", "2025-01-01")
     assert report["email"] == "max.mustermann@example.com"
     csv_path = write_report_csv(report, tmp_path, "out.csv", start="2025-01-01")
     assert csv_path.exists()
     content = csv_path.read_text()
     assert "first_name,last_name" in content
+    assert report["ai_c_group"] == "project-ai-c"
 
 
 def test_write_report_csv_append(tmp_path):

--- a/usage_report/__init__.py
+++ b/usage_report/__init__.py
@@ -3,6 +3,7 @@
 from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage, parse_elapsed, parse_tres, parse_mem
 from .report import create_report, write_report_csv
+from .groups import list_user_groups
 
 __all__ = [
     "SimAPI",
@@ -13,5 +14,6 @@ __all__ = [
     "parse_mem",
     "create_report",
     "write_report_csv",
+    "list_user_groups",
 ]
 __version__ = "0.1.0"

--- a/usage_report/groups.py
+++ b/usage_report/groups.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+from typing import List
+
+
+def list_user_groups(user: str) -> List[str]:
+    """Return the list of groups *user* belongs to using ``id`` command."""
+    proc = subprocess.run(["id", user], capture_output=True, text=True, check=True)
+    output = proc.stdout.strip()
+    try:
+        groups_part = output.split(" groups=", 1)[1]
+    except IndexError:
+        return []
+    groups = []
+    for item in groups_part.split(','):
+        if '(' in item and ')' in item:
+            start = item.find('(') + 1
+            end = item.find(')', start)
+            groups.append(item[start:end])
+    return groups

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from .api import SimAPI
 from .slurm import fetch_usage
+from .groups import list_user_groups
 
 
 def _normalize_user_data(data: dict[str, object]) -> dict[str, object]:
@@ -71,6 +72,8 @@ def create_report(user_id: str, start: str, end: str | None = None, *, netrc_fil
     api = SimAPI(netrc_file=netrc_file)
     user_data = _normalize_user_data(api.fetch_user(user_id))
     usage = fetch_usage(user_id, start, end)
+    groups = list_user_groups(user_id)
+    ai_c_group = next((g for g in groups if g.endswith("ai-c")), "")
 
     report = {
         "first_name": user_data.get("first_name")
@@ -82,6 +85,7 @@ def create_report(user_id: str, start: str, end: str | None = None, *, netrc_fil
         "email": _pick_email(user_data),
         "kennung": user_data.get("kennung"),
         "projekt": user_data.get("projekt"),
+        "ai_c_group": ai_c_group,
     }
     report.update(usage)
     return report


### PR DESCRIPTION
## Summary
- implement `list_user_groups` wrapper for `id` command
- expose `list_user_groups` in package API
- use it in `create_report` and store the first group that ends with `ai-c`
- test group extraction and updated report functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862822d5f408325b26586036f66654a