### PR TITLE
Support multiple ai-c groups

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -46,6 +46,32 @@ def test_create_report(tmp_path):
     assert report["ai_c_group"] == "project-ai-c"
 
 
+def test_create_report_multiple_ai_c(tmp_path):
+    user_info = {
+        "kennung": "mm123",
+        "projekt": "proj",
+        "daten": {
+            "vorname": "Max",
+            "nachname": "Mustermann",
+            "emailadressen": [
+                {"adresse": "max.mustermann@example.com"}
+            ],
+        },
+    }
+    usage = {"cpu_hours": 1.0, "gpu_hours": 0.5, "ram_gb_hours": 2.0}
+
+    with mock.patch("usage_report.report.SimAPI") as MockAPI:
+        api_instance = MockAPI.return_value
+        api_instance.fetch_user.return_value = user_info
+        with mock.patch("usage_report.report.fetch_usage", return_value=usage):
+            with mock.patch(
+                "usage_report.report.list_user_groups",
+                return_value=["a-ai-c", "b-ai-c"],
+            ):
+                report = create_report("mm123", "2025-01-01")
+    assert report["ai_c_group"] == "a-ai-c|b-ai-c"
+
+
 def test_write_report_csv_append(tmp_path):
     row1 = {"first_name": "A", "last_name": "B"}
     csv_path = write_report_csv(row1, tmp_path, "out.csv", start="2025-01-01")

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -73,7 +73,8 @@ def create_report(user_id: str, start: str, end: str | None = None, *, netrc_fil
     user_data = _normalize_user_data(api.fetch_user(user_id))
     usage = fetch_usage(user_id, start, end)
     groups = list_user_groups(user_id)
-    ai_c_group = next((g for g in groups if g.endswith("ai-c")), "")
+    ai_c_groups = [g for g in groups if g.endswith("ai-c")]
+    ai_c_group = "|".join(ai_c_groups) if ai_c_groups else ""
 
     report = {
         "first_name": user_data.get("first_name")


### PR DESCRIPTION
## Summary
- aggregate all ai-c groups when creating a report
- test creating a report when multiple ai-c groups are present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a812df288325a082ed9b552b111a