### PR TITLE
Add month option to usage-report CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ usage-report api <user_id> [--netrc-file PATH]
 
 # aggregate Slurm usage
 usage-report slurm <user_id> -S 2025-06-27 [-E 2025-07-01]
+# or entire month
+usage-report slurm <user_id> --month 2025-06
 
 # combined report
 usage-report report <user_id> -S 2025-06-27 [-E 2025-07-01] [--netrc-file PATH]
+# or for a whole month
+usage-report report <user_id> --month 2025-06 [--netrc-file PATH]
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from usage_report.cli import expand_month
+
+
+def test_expand_month_middle():
+    start, end = expand_month("2025-06")
+    assert start == "2025-06-01"
+    assert end == "2025-07-01"
+
+
+def test_expand_month_december():
+    start, end = expand_month("2025-12")
+    assert start == "2025-12-01"
+    assert end == "2026-01-01"

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 import argparse
 import sys
 from pprint import pprint
+from datetime import datetime
 
 from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage
 from .report import create_report, write_report_csv
+
+
+def expand_month(month: str) -> tuple[str, str]:
+    """Return start and end dates for ``month`` (``YYYY-MM``)."""
+    dt = datetime.strptime(month, "%Y-%m")
+    start = dt.replace(day=1)
+    if dt.month == 12:
+        next_month = dt.replace(year=dt.year + 1, month=1, day=1)
+    else:
+        next_month = dt.replace(month=dt.month + 1, day=1)
+    return start.strftime("%Y-%m-%d"), next_month.strftime("%Y-%m-%d")
 
 
 def _add_api_parser(sub: argparse._SubParsersAction) -> None:
@@ -23,14 +35,18 @@ def _add_api_parser(sub: argparse._SubParsersAction) -> None:
 def _add_slurm_parser(sub: argparse._SubParsersAction) -> None:
     slurm_parser = sub.add_parser("slurm", help="Calculate Slurm usage")
     slurm_parser.add_argument("user_id", help="LRZ user identifier")
-    slurm_parser.add_argument("-S", "--start", required=True, help="Start date YYYY-MM-DD")
+    grp = slurm_parser.add_mutually_exclusive_group(required=True)
+    grp.add_argument("-S", "--start", dest="start", help="Start date YYYY-MM-DD")
+    grp.add_argument("--month", help="Month YYYY-MM")
     slurm_parser.add_argument("-E", "--end", help="End date YYYY-MM-DD")
 
 
 def _add_report_parser(sub: argparse._SubParsersAction) -> None:
     report_parser = sub.add_parser("report", help="Generate combined report")
     report_parser.add_argument("user_id", help="LRZ user identifier")
-    report_parser.add_argument("-S", "--start", required=True, help="Start date YYYY-MM-DD")
+    grp = report_parser.add_mutually_exclusive_group(required=True)
+    grp.add_argument("-S", "--start", dest="start", help="Start date YYYY-MM-DD")
+    grp.add_argument("--month", help="Month YYYY-MM")
     report_parser.add_argument("-E", "--end", help="End date YYYY-MM-DD")
     report_parser.add_argument(
         "--netrc-file",
@@ -59,14 +75,28 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         pprint(data)
     elif args.command == "slurm":
-        usage = fetch_usage(args.user_id, args.start, args.end)
+        start = args.start
+        end = args.end
+        if args.month:
+            if args.end:
+                print("--end cannot be used with --month", file=sys.stderr)
+                return 1
+            start, end = expand_month(args.month)
+        usage = fetch_usage(args.user_id, start, end)
         pprint(usage)
     elif args.command == "report":
+        start = args.start
+        end = args.end
+        if args.month:
+            if args.end:
+                print("--end cannot be used with --month", file=sys.stderr)
+                return 1
+            start, end = expand_month(args.month)
         try:
             report = create_report(
                 args.user_id,
-                args.start,
-                args.end,
+                start,
+                end,
                 netrc_file=args.netrc_file,
             )
         except SimAPIError as exc:
@@ -76,13 +106,13 @@ def main(argv: list[str] | None = None) -> int:
             report,
             "output",
             f"{args.user_id}.csv",
-            start=args.start,
-            end=args.end,
+            start=start,
+            end=end,
         )
 
         report_with_period = report.copy()
-        report_with_period["period_start"] = args.start
-        report_with_period["period_end"] = args.end
+        report_with_period["period_start"] = start
+        report_with_period["period_end"] = end
 
         pprint(report_with_period)
         print(f"Report written to {output_path}")


### PR DESCRIPTION
## Summary
- add `--month` option for slurm and report subcommands
- compute start and end dates automatically from the month
- document month usage in README
- test month expansion helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686421a981fc832591f92eae43bd1349