### PR TITLE
Add partition filtering for Slurm usage

### DIFF
--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -21,9 +21,9 @@ def test_parse_mem():
 
 def test_fetch_usage():
     sample = (
-        "JobID|Elapsed|NCPUS|AllocTRES\n"
-        "123|01:00:00|4|cpu=4,mem=8000M,gres/gpu=2\n"
-        "123.batch|00:10:00|4|cpu=4,mem=8000M,gres/gpu=2\n"
+        "JobID|Partition|Elapsed|NCPUS|AllocTRES\n"
+        "123|gpu|01:00:00|4|cpu=4,mem=8000M,gres/gpu=2\n"
+        "123.batch|gpu|00:10:00|4|cpu=4,mem=8000M,gres/gpu=2\n"
     )
     mocked_proc = mock.Mock(stdout=sample)
     with mock.patch("subprocess.run", return_value=mocked_proc):
@@ -31,3 +31,17 @@ def test_fetch_usage():
     assert usage["cpu_hours"] == 4.0
     assert usage["gpu_hours"] == 2.0
     assert usage["ram_gb_hours"] == pytest.approx(8.0, rel=0.05)
+
+
+def test_fetch_usage_partition_filter():
+    sample = (
+        "JobID|Partition|Elapsed|NCPUS|AllocTRES\n"
+        "1|lrz-gpu|01:00:00|4|cpu=4,mem=8000M,gres/gpu=2\n"
+        "2|mcml-cpu|02:00:00|8|cpu=8,mem=16000M\n"
+    )
+    mocked_proc = mock.Mock(stdout=sample)
+    with mock.patch("subprocess.run", return_value=mocked_proc):
+        usage = fetch_usage("user", "2025-01-01", partitions=["lrz*"])
+    assert usage["gpu_hours"] == 2.0
+    assert usage["cpu_hours"] == 4.0
+

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -39,6 +39,13 @@ def _add_slurm_parser(sub: argparse._SubParsersAction) -> None:
     grp.add_argument("-S", "--start", dest="start", help="Start date YYYY-MM-DD")
     grp.add_argument("--month", help="Month YYYY-MM")
     slurm_parser.add_argument("-E", "--end", help="End date YYYY-MM-DD")
+    slurm_parser.add_argument(
+        "-p",
+        "--partition",
+        dest="partitions",
+        action="append",
+        help="Partition to include (can be used multiple times, supports wildcards)",
+    )
 
 
 def _add_report_parser(sub: argparse._SubParsersAction) -> None:
@@ -52,6 +59,13 @@ def _add_report_parser(sub: argparse._SubParsersAction) -> None:
         "--netrc-file",
         dest="netrc_file",
         help="Custom path to .netrc file for authentication",
+    )
+    report_parser.add_argument(
+        "-p",
+        "--partition",
+        dest="partitions",
+        action="append",
+        help="Partition to include (can be used multiple times, supports wildcards)",
     )
 
 
@@ -82,7 +96,7 @@ def main(argv: list[str] | None = None) -> int:
                 print("--end cannot be used with --month", file=sys.stderr)
                 return 1
             start, end = expand_month(args.month)
-        usage = fetch_usage(args.user_id, start, end)
+        usage = fetch_usage(args.user_id, start, end, partitions=args.partitions)
         pprint(usage)
     elif args.command == "report":
         start = args.start
@@ -97,6 +111,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.user_id,
                 start,
                 end,
+                partitions=args.partitions,
                 netrc_file=args.netrc_file,
             )
         except SimAPIError as exc:

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 import csv
 from datetime import datetime
+from typing import Iterable
 
 from .api import SimAPI
 from .slurm import fetch_usage
@@ -67,11 +68,18 @@ def _pick_email(data: dict[str, object]) -> str:
     return ""
 
 
-def create_report(user_id: str, start: str, end: str | None = None, *, netrc_file: str | Path | None = None) -> dict[str, object]:
+def create_report(
+    user_id: str,
+    start: str,
+    end: str | None = None,
+    *,
+    partitions: Iterable[str] | None = None,
+    netrc_file: str | Path | None = None,
+) -> dict[str, object]:
     """Return a combined report dictionary for *user_id*."""
     api = SimAPI(netrc_file=netrc_file)
     user_data = _normalize_user_data(api.fetch_user(user_id))
-    usage = fetch_usage(user_id, start, end)
+    usage = fetch_usage(user_id, start, end, partitions=partitions)
     groups = list_user_groups(user_id)
     ai_c_groups = [g for g in groups if g.endswith("ai-c")]
     ai_c_group = "|".join(ai_c_groups) if ai_c_groups else ""


### PR DESCRIPTION
## Summary
- allow specifying partitions when aggregating Slurm usage
- support wildcard patterns for partitions
- expose partition option through CLI and report utilities
- test partition filtering logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642301bcfc832585edd4d4b0d85068