### PR TITLE
Fix month range end date

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ pip install -e .
 usage-report api <user_id> [--netrc-file PATH]
 
 # aggregate Slurm usage
-usage-report slurm <user_id> -S 2025-06-27 [-E 2025-07-01]
+usage-report slurm <user_id> -S 2025-06-27 [-E 2025-06-30]
 # or entire month
 usage-report slurm <user_id> --month 2025-06
 
 # combined report
-usage-report report <user_id> -S 2025-06-27 [-E 2025-07-01] [--netrc-file PATH]
+usage-report report <user_id> -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
 # or for a whole month
 usage-report report <user_id> --month 2025-06 [--netrc-file PATH]
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,10 @@ from usage_report.cli import expand_month
 def test_expand_month_middle():
     start, end = expand_month("2025-06")
     assert start == "2025-06-01"
-    assert end == "2025-07-01"
+    assert end == "2025-06-30"
 
 
 def test_expand_month_december():
     start, end = expand_month("2025-12")
     assert start == "2025-12-01"
-    assert end == "2026-01-01"
+    assert end == "2025-12-31"

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pprint import pprint
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage
@@ -19,7 +19,8 @@ def expand_month(month: str) -> tuple[str, str]:
         next_month = dt.replace(year=dt.year + 1, month=1, day=1)
     else:
         next_month = dt.replace(month=dt.month + 1, day=1)
-    return start.strftime("%Y-%m-%d"), next_month.strftime("%Y-%m-%d")
+    last_day = next_month - timedelta(days=1)
+    return start.strftime("%Y-%m-%d"), last_day.strftime("%Y-%m-%d")
 
 
 def _add_api_parser(sub: argparse._SubParsersAction) -> None:


### PR DESCRIPTION
## Summary
- adjust `expand_month` to stop at the last day of the month
- update CLI unit tests
- adjust README examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642424e1648325ac993dde29881f5b