### PR TITLE
Implement database-backed active usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ usage-report slurm <user_id> --month 2025-06 \
 #     --partition 'lrz*' --partition 'mcml*'
 
 # cluster usage for active users
-usage-report active --month 2025-06 -u user1 -u user2
+usage-report report active -S 2025-06-27 [-E 2025-06-30]
 
 # combined report
 usage-report report <user_id> -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
 # or for a whole month
 usage-report report <user_id> --month 2025-06 [--netrc-file PATH]
     --partition lrz* --partition mcml*
+# list stored monthly data
+usage-report report list
+# show stored month
+usage-report report show 2025-06
 ```

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from usage_report.database import store_month, load_month, list_months
+
+
+def test_store_and_load_month(tmp_path):
+    db = tmp_path / "test.db"
+    usage = {"user1": 10.0}
+    store_month("2025-06", "2025-06-01", "2025-06-30", usage, partitions=["gpu"], db_path=db)
+    result = load_month("2025-06", partitions=["gpu"], db_path=db)
+    assert result == usage
+    entries = list_months(db_path=db)
+    assert entries[0]["month"] == "2025-06"

--- a/tests/test_sreport.py
+++ b/tests/test_sreport.py
@@ -24,5 +24,12 @@ def test_fetch_active_usage():
     """
     mocked_proc = mock.Mock(stdout=sample_output)
     with mock.patch("subprocess.run", return_value=mocked_proc):
-        usage = fetch_active_usage("2025-06-01", "2025-06-30", active_users=["user1", "user2"])
-    assert usage == {"user1": 10.0, "user2": 5.0}
+        usage = fetch_active_usage(
+            "2025-06-01",
+            "2025-06-30",
+            active_users=["user1", "user2"],
+            partitions=["gpu"],
+        )
+    assert usage["partitions"] == ["gpu"]
+    assert usage["user1"] == 10.0
+    assert usage["user2"] == 5.0

--- a/usage_report/__init__.py
+++ b/usage_report/__init__.py
@@ -4,6 +4,7 @@ from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage, parse_elapsed, parse_tres, parse_mem
 from .report import create_report, write_report_csv
 from .sreport import fetch_active_usage, parse_sreport_output
+from .database import store_month, load_month, list_months
 from .groups import list_user_groups
 
 __all__ = [
@@ -18,5 +19,8 @@ __all__ = [
     "list_user_groups",
     "fetch_active_usage",
     "parse_sreport_output",
+    "store_month",
+    "load_month",
+    "list_months",
 ]
 __version__ = "0.1.0"

--- a/usage_report/database.py
+++ b/usage_report/database.py
@@ -1,0 +1,84 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Dict, Any
+
+
+DEFAULT_DB_PATH = Path("output/usage.db")
+
+
+def init_db(db_path: Path = DEFAULT_DB_PATH) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS monthly_usage (
+            month TEXT NOT NULL,
+            start TEXT NOT NULL,
+            end TEXT NOT NULL,
+            partitions TEXT NOT NULL,
+            data TEXT NOT NULL,
+            PRIMARY KEY (month, partitions)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def store_month(
+    month: str,
+    start: str,
+    end: str,
+    usage: Dict[str, float],
+    *,
+    partitions: Iterable[str] | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> None:
+    """Store *usage* for *month* in the database."""
+    init_db(db_path)
+    conn = sqlite3.connect(db_path)
+    parts = ",".join(sorted(partitions or []))
+    data = json.dumps(usage)
+    conn.execute(
+        "REPLACE INTO monthly_usage (month, start, end, partitions, data) VALUES (?, ?, ?, ?, ?)",
+        (month, start, end, parts, data),
+    )
+    conn.commit()
+    conn.close()
+
+
+def load_month(
+    month: str,
+    *,
+    partitions: Iterable[str] | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> Dict[str, float] | None:
+    """Return stored usage for *month* or ``None`` if not found."""
+    init_db(db_path)
+    parts = ",".join(sorted(partitions or []))
+    conn = sqlite3.connect(db_path)
+    cur = conn.execute(
+        "SELECT data FROM monthly_usage WHERE month=? AND partitions=?",
+        (month, parts),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return json.loads(row[0])
+    return None
+
+
+def list_months(db_path: Path = DEFAULT_DB_PATH) -> list[dict[str, Any]]:
+    """Return a list of all stored months."""
+    init_db(db_path)
+    conn = sqlite3.connect(db_path)
+    cur = conn.execute(
+        "SELECT month, start, end, partitions FROM monthly_usage ORDER BY month"
+    )
+    rows = [
+        {"month": r[0], "start": r[1], "end": r[2], "partitions": r[3]}
+        for r in cur.fetchall()
+    ]
+    conn.close()
+    return rows


### PR DESCRIPTION
## Summary
- support nested `report` subcommands and add `active`, `list`, and `show`
- add SQLite helper module for storing monthly active usage data
- extend `fetch_active_usage` with partition tracking
- update CLI and README for new commands
- add tests for database helpers and updated active usage behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643270e4648325a8193a5fc79bdac7