### PR TITLE
Rename CLI to usage and improve output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,29 @@ pip install -e .
 
 ```bash
 # fetch information from the SIM API
-usage-report api <user_id> [--netrc-file PATH]
+usage api <user_id> [--netrc-file PATH]
 
 # aggregate Slurm usage
-usage-report slurm <user_id> -S 2025-06-27 [-E 2025-06-30]
+usage slurm <user_id> -S 2025-06-27 [-E 2025-06-30]
 # or entire month
-usage-report slurm <user_id> --month 2025-06
+usage slurm <user_id> --month 2025-06
 # filter by partition (can be used multiple times, supports wildcards)
-usage-report slurm <user_id> --month 2025-06 \
+usage slurm <user_id> --month 2025-06 \
     --partition lrz* --partition mcml*
 # quote wildcards to prevent shell expansion if needed
-# usage-report slurm <user_id> --month 2025-06 \
+# usage slurm <user_id> --month 2025-06 \
 #     --partition 'lrz*' --partition 'mcml*'
 
 # cluster usage for active users
-usage-report report active -S 2025-06-27 [-E 2025-06-30]
+usage report active -S 2025-06-27 [-E 2025-06-30]
 
 # combined report
-usage-report report <user_id> -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
+usage report <user_id> -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
 # or for a whole month
-usage-report report <user_id> --month 2025-06 [--netrc-file PATH]
+usage report <user_id> --month 2025-06 [--netrc-file PATH]
     --partition lrz* --partition mcml*
 # list stored monthly data
-usage-report report list
+usage report list
 # show stored month
-usage-report report show 2025-06
+usage report show 2025-06
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "usage-report"
+name = "usage"
 version = "0.1.0"
 description = "Utilities to fetch usage information from LRZ SIM API"
 readme = "README.md"
@@ -14,7 +14,7 @@ authors = [
 dependencies = []
 
 [project.scripts]
-usage-report = "usage_report.cli:main"
+usage = "usage_report.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- rename `usage-report` script to `usage`
- update docs and packaging accordingly
- add helper to print stored month data as a formatted table
- use the table for `usage report show`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864edbf88d48325bc384341681a4f78