### PR TITLE
Implement partition-aware storage and enhanced show command

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -39,7 +39,13 @@ def test_create_report(tmp_path):
             with mock.patch("usage_report.report.list_user_groups", return_value=["users", "project-ai-c", "other"]):
                 report = create_report("mm123", "2025-01-01")
     assert report["email"] == "max.mustermann@example.com"
-    csv_path = write_report_csv(report, tmp_path, "out.csv", start="2025-01-01")
+    csv_path = write_report_csv(
+        report,
+        tmp_path,
+        "out.csv",
+        start="2025-01-01",
+        partitions=["gpu"],
+    )
     assert csv_path.exists()
     content = csv_path.read_text()
     assert "first_name,last_name" in content
@@ -74,9 +80,10 @@ def test_create_report_multiple_ai_c(tmp_path):
 
 def test_write_report_csv_append(tmp_path):
     row1 = {"first_name": "A", "last_name": "B"}
-    csv_path = write_report_csv(row1, tmp_path, "out.csv", start="2025-01-01")
+    csv_path = write_report_csv(row1, tmp_path, "out.csv", start="2025-01-01", partitions=["gpu"])
     row2 = {"first_name": "C", "last_name": "D"}
-    csv_path = write_report_csv(row2, tmp_path, "out.csv", start="2025-02-01")
+    csv_path = write_report_csv(row2, tmp_path, "out.csv", start="2025-02-01", partitions=["gpu"])
     lines = csv_path.read_text().splitlines()
     assert len(lines) == 3
     assert "timestamp" in lines[0]
+    assert "partitions" in lines[0]

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -107,11 +107,14 @@ def write_report_csv(
     *,
     start: str | None = None,
     end: str | None = None,
+    partitions: Iterable[str] | None = None,
 ) -> Path:
     """Write *report* to ``output_dir/filename`` and return the path.
 
     If the file already exists, the row is appended.  A ``timestamp`` as well
     as ``period_start`` and ``period_end`` columns are added automatically.
+    The ``partitions`` column records which partitions were included in the
+    calculation, joined by commas.
     """
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -121,6 +124,7 @@ def write_report_csv(
     row["timestamp"] = datetime.now().isoformat(timespec="seconds")
     row["period_start"] = start
     row["period_end"] = end or ""
+    row["partitions"] = ",".join(sorted(partitions or []))
 
     if out_path.exists():
         with out_path.open("r", newline="") as fh:


### PR DESCRIPTION
## Summary
- track partitions when writing report CSVs
- avoid recalculating active usage if month data already exists
- improve `report show` with auto partition selection and period display
- print usage tables with start/end period information
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f568d4988325bfc73b715145e0d7