### PR TITLE
Switch to horizontal report layout

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,7 +6,21 @@ from usage_report.database import store_month, load_month, list_months
 
 def test_store_and_load_month(tmp_path):
     db = tmp_path / "test.db"
-    usage = {"user1": 10.0}
+    row = {
+        "first_name": "A",
+        "last_name": "B",
+        "email": "a@example.com",
+        "kennung": "user1",
+        "projekt": "proj",
+        "ai_c_group": "",
+        "cpu_hours": 10.0,
+        "gpu_hours": 0.0,
+        "ram_gb_hours": 0.0,
+        "timestamp": "ts",
+        "period_start": "2025-06-01",
+        "period_end": "2025-06-30",
+    }
+    usage = [row]
     store_month("2025-06", "2025-06-01", "2025-06-30", usage, partitions=["gpu"], db_path=db)
     result = load_month("2025-06", partitions=["gpu"], db_path=db)
     assert result == usage

--- a/usage_report/database.py
+++ b/usage_report/database.py
@@ -1,7 +1,7 @@
 import json
 import sqlite3
 from pathlib import Path
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, List
 
 
 DEFAULT_DB_PATH = Path("output/usage.db")
@@ -30,7 +30,7 @@ def store_month(
     month: str,
     start: str,
     end: str,
-    usage: Dict[str, float],
+    usage: Iterable[Dict[str, Any]],
     *,
     partitions: Iterable[str] | None = None,
     db_path: Path = DEFAULT_DB_PATH,
@@ -39,7 +39,7 @@ def store_month(
     init_db(db_path)
     conn = sqlite3.connect(db_path)
     parts = ",".join(sorted(partitions or []))
-    data = json.dumps(usage)
+    data = json.dumps(list(usage))
     conn.execute(
         "REPLACE INTO monthly_usage (month, start, end, partitions, data) VALUES (?, ?, ?, ?, ?)",
         (month, start, end, parts, data),
@@ -53,7 +53,7 @@ def load_month(
     *,
     partitions: Iterable[str] | None = None,
     db_path: Path = DEFAULT_DB_PATH,
-) -> Dict[str, float] | None:
+) -> List[Dict[str, Any]] | None:
     """Return stored usage for *month* or ``None`` if not found."""
     init_db(db_path)
     parts = ",".join(sorted(partitions or []))


### PR DESCRIPTION
## Summary
- rework `print_usage_table` and `print_report_table` to output a single row with
  columns
- adjust CLI `report active` and `report show` to use the new format
- store monthly data in the database as a list of user records instead of a mapping
- update tests for the new database format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686537d118a88325ba3832bcfd29313f