### PR TITLE
Add active report helper

### DIFF
--- a/usage_report/__init__.py
+++ b/usage_report/__init__.py
@@ -2,7 +2,7 @@
 
 from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage, parse_elapsed, parse_tres, parse_mem
-from .report import create_report, write_report_csv
+from .report import create_report, create_active_reports, write_report_csv
 from .sreport import fetch_active_usage, parse_sreport_output
 from .database import store_month, load_month, list_months
 from .groups import list_user_groups
@@ -15,6 +15,7 @@ __all__ = [
     "parse_tres",
     "parse_mem",
     "create_report",
+    "create_active_reports",
     "write_report_csv",
     "list_user_groups",
     "fetch_active_usage",

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -10,7 +10,7 @@ from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage
 from .sreport import fetch_active_usage
 from .database import store_month, list_months, load_month
-from .report import create_report, write_report_csv
+from .report import create_report, create_active_reports, write_report_csv
 
 
 def expand_month(month: str) -> tuple[str, str]:
@@ -280,20 +280,12 @@ def main(argv: list[str] | None = None) -> int:
                 for row in rows:
                     print_report_table(row)
             else:
-                active = fetch_active_usage(start, end, partitions=args.partitions)
-                user_ids = [u for u in active if u != "partitions"]
-                rows = []
-                for user in user_ids:
-                    report = create_report(
-                        user,
-                        start,
-                        end,
-                        partitions=args.partitions,
-                    )
-                    report["period_start"] = start
-                    report["period_end"] = end
-                    report["timestamp"] = datetime.now().isoformat(timespec="seconds")
-                    rows.append(report)
+                rows = create_active_reports(
+                    start,
+                    end,
+                    partitions=args.partitions,
+                )
+                for report in rows:
                     print_report_table(report)
 
                 if args.month:


### PR DESCRIPTION
## Summary
- make CLI `report active` use a new `create_active_reports` helper
- implement `create_active_reports` to enrich sreport users via sacct and SIM API data
- expose the helper in the public package API
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653aed0fbc8325b3b27ded7fad5a0b