### PR TITLE
Fix load_month for legacy single-row data

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -26,3 +26,22 @@ def test_store_and_load_month(tmp_path):
     assert result == usage
     entries = list_months(db_path=db)
     assert entries[0]["month"] == "2025-06"
+
+
+def test_load_month_single_row(tmp_path):
+    db = tmp_path / "test.db"
+    row = {"first_name": "A", "last_name": "B"}
+    from usage_report.database import init_db
+    import sqlite3, json
+
+    init_db(db_path=db)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "REPLACE INTO monthly_usage (month, start, end, partitions, data) VALUES (?, ?, ?, ?, ?)",
+        ("2025-07", "2025-07-01", "2025-07-31", "", json.dumps(row)),
+    )
+    conn.commit()
+    conn.close()
+
+    result = load_month("2025-07", db_path=db)
+    assert result == [row]

--- a/usage_report/database.py
+++ b/usage_report/database.py
@@ -65,7 +65,11 @@ def load_month(
     row = cur.fetchone()
     conn.close()
     if row:
-        return json.loads(row[0])
+        data = json.loads(row[0])
+        if isinstance(data, dict):
+            # Support legacy entries storing a single dictionary
+            data = [data]
+        return data
     return None
 
 


### PR DESCRIPTION
## Summary
- handle legacy entries in `load_month` that store a single dictionary
- test that `load_month` supports legacy single-row format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653c8e5980832597362c5775288ebd