### PR TITLE
Fix active report fallback for legacy data

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,3 +24,18 @@ def test_report_user_alias():
     assert args.report_cmd == "user"
     assert args.user_id == "di38qex"
     assert args.month == "2025-06"
+
+
+def test_report_active_legacy(monkeypatch):
+    from usage_report import cli
+    legacy = [{"user1": 1.0}]
+    monkeypatch.setattr(cli, "load_month", lambda month, partitions=None: legacy)
+    called = {}
+    def fake_create(start, end, partitions=None):
+        called['yes'] = True
+        return [{"kennung": "u1"}]
+    monkeypatch.setattr(cli, "create_active_reports", fake_create)
+    monkeypatch.setattr(cli, "store_month", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "print_report_table", lambda row: None)
+    cli.main(["report", "active", "--month", "2025-06"])
+    assert called.get('yes')

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -282,6 +282,23 @@ def main(argv: list[str] | None = None) -> int:
                 existing = load_month(args.month, partitions=args.partitions)
             if existing is not None:
                 rows = list(existing)
+                sample = rows[0] if rows else {}
+                if not isinstance(sample, dict) or "kennung" not in sample:
+                    rows = create_active_reports(
+                        start,
+                        end,
+                        partitions=args.partitions,
+                    )
+                    if args.month:
+                        store_month(
+                            args.month,
+                            start,
+                            end or "",
+                            rows,
+                            partitions=args.partitions,
+                        )
+                else:
+                    rows = enrich_report_rows(rows)
                 for row in rows:
                     print_report_table(row)
             else:


### PR DESCRIPTION
## Summary
- ensure `usage report active` regenerates reports when stored data lacks per-user entries
- enrich stored rows and print them
- test handling of legacy data in CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686541745514832583b29878ba60f807