### PR TITLE
Fix netrc parameter for active report

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ usage slurm <user_id> --month 2025-06 \
 #     --partition 'lrz*' --partition 'mcml*'
 
 # cluster usage for active users
-usage report active -S 2025-06-27 [-E 2025-06-30]
+usage report active -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
 
 # combined report
 usage report <user_id> -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
@@ -36,5 +36,5 @@ usage report <user_id> --month 2025-06 [--netrc-file PATH]
 # list stored monthly data
 usage report list
 # show stored month
-usage report show --month 2025-06
+usage report show --month 2025-06 [--netrc-file PATH]
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,7 @@ def test_report_active_legacy(monkeypatch):
     legacy = [{"user1": 1.0}]
     monkeypatch.setattr(cli, "load_month", lambda month, partitions=None: legacy)
     called = {}
-    def fake_create(start, end, partitions=None):
+    def fake_create(start, end, partitions=None, netrc_file=None):
         called['yes'] = True
         return [{"kennung": "u1"}]
     monkeypatch.setattr(cli, "create_active_reports", fake_create)
@@ -39,3 +39,21 @@ def test_report_active_legacy(monkeypatch):
     monkeypatch.setattr(cli, "print_report_table", lambda row: None)
     cli.main(["report", "active", "--month", "2025-06"])
     assert called.get('yes')
+
+
+def test_report_active_netrc(monkeypatch):
+    from usage_report import cli
+
+    monkeypatch.setattr(cli, "load_month", lambda *a, **k: None)
+    captured = {}
+
+    def fake_create(start, end, partitions=None, netrc_file=None):
+        captured["netrc"] = netrc_file
+        return []
+
+    monkeypatch.setattr(cli, "create_active_reports", fake_create)
+    monkeypatch.setattr(cli, "store_month", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "print_report_table", lambda row: None)
+
+    cli.main(["report", "active", "--month", "2025-06", "--netrc-file", "creds"]) 
+    assert captured.get("netrc") == "creds"

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -141,6 +141,11 @@ def _add_report_parser(sub: argparse._SubParsersAction) -> None:
     grp_a.add_argument("--month", help="Month YYYY-MM")
     active_parser.add_argument("-E", "--end", help="End date YYYY-MM-DD")
     active_parser.add_argument(
+        "--netrc-file",
+        dest="netrc_file",
+        help="Custom path to .netrc file for authentication",
+    )
+    active_parser.add_argument(
         "-p",
         "--partition",
         dest="partitions",
@@ -158,6 +163,11 @@ def _add_report_parser(sub: argparse._SubParsersAction) -> None:
         dest="partitions",
         action="append",
         help="Partition filter used during storage",
+    )
+    show_parser.add_argument(
+        "--netrc-file",
+        dest="netrc_file",
+        help="Custom path to .netrc file for authentication",
     )
 
 
@@ -288,6 +298,7 @@ def main(argv: list[str] | None = None) -> int:
                         start,
                         end,
                         partitions=args.partitions,
+                        netrc_file=args.netrc_file,
                     )
                     if args.month:
                         store_month(
@@ -298,7 +309,7 @@ def main(argv: list[str] | None = None) -> int:
                             partitions=args.partitions,
                         )
                 else:
-                    rows = enrich_report_rows(rows)
+                    rows = enrich_report_rows(rows, netrc_file=args.netrc_file)
                 for row in rows:
                     print_report_table(row)
             else:
@@ -306,6 +317,7 @@ def main(argv: list[str] | None = None) -> int:
                     start,
                     end,
                     partitions=args.partitions,
+                    netrc_file=args.netrc_file,
                 )
                 for report in rows:
                     print_report_table(report)
@@ -342,7 +354,7 @@ def main(argv: list[str] | None = None) -> int:
                         print_usage_table([])
                     return 0
             usage = load_month(args.month, partitions=parts) or []
-            usage = enrich_report_rows(usage)
+            usage = enrich_report_rows(usage, netrc_file=args.netrc_file)
             match = next(
                 (e for e in entries if e["partitions"] == ",".join(sorted(parts or []))),
                 None,


### PR DESCRIPTION
## Summary
- add `--netrc-file` option for `report active` and `report show`
- pass that option through CLI to `create_active_reports` and `enrich_report_rows`
- document new option in README
- test CLI handling of the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686572896838832592a4728a58418651