### PR TITLE
Add tests for SimAPI HTTP error handling

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from unittest import mock
+from urllib import error
 
 import pytest
 
@@ -39,3 +40,38 @@ def test_fetch_user_failure():
         with mock.patch("urllib.request.urlopen", return_value=dummy):
             with pytest.raises(SimAPIError):
                 api.fetch_user("baduser")
+
+
+def test_fetch_user_http_error():
+    api = SimAPI()
+    http_err = error.HTTPError(
+        api.BASE_URL + "baduser",
+        403,
+        "Forbidden",
+        hdrs=None,
+        fp=None,
+    )
+    with mock.patch.object(api, "_get_auth", return_value=("u", "p")):
+        with mock.patch("urllib.request.urlopen", side_effect=http_err):
+            with pytest.raises(SimAPIError):
+                api.fetch_user("baduser")
+
+
+def test_fetch_user_request_headers(monkeypatch):
+    api = SimAPI()
+    captured = {}
+
+    def fake_urlopen(req):
+        captured["url"] = req.full_url
+        captured["auth"] = req.headers.get("Authorization")
+        captured["accept"] = req.headers.get("Accept")
+        return DummyResponse(200, b"{}")
+
+    monkeypatch.setattr(api, "_get_auth", lambda: ("u", "p"))
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    api.fetch_user("testuser")
+
+    assert captured["url"].endswith("testuser")
+    assert captured["auth"].startswith("Basic ")
+    assert captured["accept"] == "application/json"


### PR DESCRIPTION
## Summary
- extend API tests to cover HTTPError scenarios
- ensure HTTP headers and request URL are validated when calling SimAPI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865744dab6c8325a7402c0a076b46fd