### PR TITLE
Improve logging around SIM API errors

### DIFF
--- a/usage_report/api.py
+++ b/usage_report/api.py
@@ -7,7 +7,10 @@ import base64
 from pathlib import Path
 from typing import Any
 
+import logging
 from urllib import request, error
+
+logger = logging.getLogger(__name__)
 
 
 class SimAPIError(Exception):
@@ -21,6 +24,7 @@ class SimAPI:
 
     def __init__(self, netrc_file: str | Path | None = None) -> None:
         self.netrc_file = Path(netrc_file) if netrc_file else Path.home() / ".netrc"
+        logger.debug("Using netrc file %s", self.netrc_file)
 
     def _get_auth(self) -> tuple[str, str]:
         try:
@@ -45,15 +49,21 @@ class SimAPI:
         headers = {"Accept": "application/json"}
         credentials = f"{login}:{password}".encode()
         headers["Authorization"] = "Basic " + base64.b64encode(credentials).decode()
+        logger.debug("Fetching user %s from %s", user_id, url)
         req = request.Request(url, headers=headers)
         try:
             with request.urlopen(req) as resp:
+                body = resp.read().decode()
+                logger.debug("SIM API responded with status %s", resp.status)
                 if resp.status != 200:
-                    raise SimAPIError(f"API request failed with status {resp.status}: {resp.read().decode()}")
-                data = resp.read().decode()
+                    logger.debug("Response body: %s", body)
+                    raise SimAPIError(
+                        f"API request failed with status {resp.status}: {body}"
+                    )
         except error.URLError as err:
+            logger.error("Failed to contact SIM API: %s", err)
             raise SimAPIError(f"Failed to contact API: {err}") from err
         try:
-            return json.loads(data)
+            return json.loads(body)
         except json.JSONDecodeError as err:
             raise SimAPIError("Failed to decode JSON response") from err


### PR DESCRIPTION
## Summary
- add debug logger for API requests
- log netrc file location and API request/response details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686578e3b2e88325be2b8a1df937b19b