### PR TITLE
Add --debug option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ pip install -e .
 ## Command line usage
 
 ```bash
+# enable debug logging
+usage --debug <command> [options]
+
 # fetch information from the SIM API
 usage sim <user_id> [--netrc-file PATH]
 

--- a/tests/test_debug_option.py
+++ b/tests/test_debug_option.py
@@ -1,0 +1,8 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from usage_report.cli import parse_args
+
+
+def test_parse_debug():
+    args = parse_args(["--debug", "report", "list"])
+    assert args.debug is True

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -5,6 +5,7 @@ import argparse
 import sys
 from pprint import pprint
 from datetime import datetime, timedelta
+import logging
 
 from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage
@@ -206,6 +207,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             argv_list.insert(1, "user")
 
     parser = argparse.ArgumentParser(description="Usage reporting utilities")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
     _add_sim_parser(sub)
     _add_slurm_parser(sub)
@@ -216,6 +222,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if getattr(args, "debug", False):
+        logging.basicConfig(level=logging.DEBUG)
     if args.command == "sim":
         api = SimAPI(netrc_file=args.netrc_file)
         try:


### PR DESCRIPTION
## Summary
- add global `--debug` option to the CLI
- enable logging when `--debug` is passed
- document the option in the README
- add unit test for the new flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686579dcff5c83258c2724323fecdb00