### PR TITLE
Allow --debug anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ pip install -e .
 ## Command line usage
 
 ```bash
-# enable debug logging
-usage --debug <command> [options]
+# enable debug logging (option can be placed anywhere)
+usage [--debug] <command> [options]
 
 # fetch information from the SIM API
 usage sim <user_id> [--netrc-file PATH]

--- a/tests/test_debug_option.py
+++ b/tests/test_debug_option.py
@@ -6,3 +6,8 @@ from usage_report.cli import parse_args
 def test_parse_debug():
     args = parse_args(["--debug", "report", "list"])
     assert args.debug is True
+
+
+def test_parse_debug_end():
+    args = parse_args(["report", "active", "--month", "2025-06", "--debug"])
+    assert args.debug is True

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -198,6 +198,10 @@ def _add_active_parser(sub: argparse._SubParsersAction) -> None:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     argv_list = list(argv) if argv is not None else sys.argv[1:]
+    debug = False
+    while "--debug" in argv_list:
+        argv_list.remove("--debug")
+        debug = True
     if argv_list and argv_list[0] == "report":
         if (
             len(argv_list) > 1
@@ -217,7 +221,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     _add_slurm_parser(sub)
     _add_report_parser(sub)
     _add_active_parser(sub)
-    return parser.parse_args(argv_list)
+    args = parser.parse_args(argv_list)
+    if debug:
+        args.debug = True
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary
- let `--debug` be placed anywhere on the command line
- document new flexibility in README
- test that debug option works at the end of arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657dc36c948325bb61ef77c72580c2