### PR TITLE
Improve active report output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_report_active_legacy(monkeypatch):
         return [{"kennung": "u1"}]
     monkeypatch.setattr(cli, "create_active_reports", fake_create)
     monkeypatch.setattr(cli, "store_month", lambda *a, **k: None)
-    monkeypatch.setattr(cli, "print_report_table", lambda row: None)
+    monkeypatch.setattr(cli, "print_usage_table", lambda rows, *a, **k: None)
     cli.main(["report", "active", "--month", "2025-06"])
     assert called.get('yes')
 
@@ -53,7 +53,7 @@ def test_report_active_netrc(monkeypatch):
 
     monkeypatch.setattr(cli, "create_active_reports", fake_create)
     monkeypatch.setattr(cli, "store_month", lambda *a, **k: None)
-    monkeypatch.setattr(cli, "print_report_table", lambda row: None)
+    monkeypatch.setattr(cli, "print_usage_table", lambda rows, *a, **k: None)
 
     cli.main(["report", "active", "--month", "2025-06", "--netrc-file", "creds"]) 
     assert captured.get("netrc") == "creds"

--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -325,8 +325,7 @@ def main(argv: list[str] | None = None) -> int:
                         )
                 else:
                     rows = enrich_report_rows(rows, netrc_file=args.netrc_file)
-                for row in rows:
-                    print_report_table(row)
+                print_usage_table(rows)
             else:
                 rows = create_active_reports(
                     start,
@@ -334,8 +333,7 @@ def main(argv: list[str] | None = None) -> int:
                     partitions=args.partitions,
                     netrc_file=args.netrc_file,
                 )
-                for report in rows:
-                    print_report_table(report)
+                print_usage_table(rows)
 
                 if args.month:
                     store_month(


### PR DESCRIPTION
## Summary
- print active report rows in a single usage table
- update CLI tests for changed function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658543c77883258f93be9afa143f91