### PR TITLE
Handle missing users in group lookup

### DIFF
--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from unittest import mock
+import subprocess
 
 from usage_report.groups import list_user_groups
 
@@ -12,3 +13,10 @@ def test_list_user_groups():
     with mock.patch("subprocess.run", return_value=mocked_proc):
         groups = list_user_groups("user")
     assert groups == ["user", "sudo", "test-ai-c"]
+
+
+def test_list_user_groups_error():
+    error = subprocess.CalledProcessError(1, ["id", "user"], stderr="fail")
+    with mock.patch("subprocess.run", side_effect=error):
+        groups = list_user_groups("user")
+    assert groups == []

--- a/usage_report/groups.py
+++ b/usage_report/groups.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import List
 
 
 def list_user_groups(user: str) -> List[str]:
     """Return the list of groups *user* belongs to using ``id`` command."""
-    proc = subprocess.run(["id", user], capture_output=True, text=True, check=True)
+    try:
+        proc = subprocess.run(
+            ["id", user], capture_output=True, text=True, check=True
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = " ".join(exc.cmd) if isinstance(exc.cmd, list) else str(exc.cmd)
+        print(f"Error running '{msg}': {exc}", file=sys.stderr)
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr)
+        return []
     output = proc.stdout.strip()
     try:
         groups_part = output.split(" groups=", 1)[1]


### PR DESCRIPTION
## Summary
- handle missing system users gracefully by catching errors from `id`
- test that `list_user_groups` returns an empty list on error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686586a49d1c832587e5aa3d646280f7