### PR TITLE
Add --sortby option with default GPU hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,8 @@ usage report <user_id> --month 2025-06 [--netrc-file PATH]
 usage report list
 # show stored month
 usage report show --month 2025-06 [--netrc-file PATH]
+# default sort by GPU hours descending
+usage report show --month 2025-06
+# custom sort column
+usage report show --month 2025-06 --sortby last_name
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,5 +55,70 @@ def test_report_active_netrc(monkeypatch):
     monkeypatch.setattr(cli, "store_month", lambda *a, **k: None)
     monkeypatch.setattr(cli, "print_usage_table", lambda rows, *a, **k: None)
 
-    cli.main(["report", "active", "--month", "2025-06", "--netrc-file", "creds"]) 
+    cli.main(["report", "active", "--month", "2025-06", "--netrc-file", "creds"])
     assert captured.get("netrc") == "creds"
+
+
+def test_show_sort_parse():
+    from usage_report.cli import parse_args
+
+    args = parse_args([
+        "report",
+        "show",
+        "--month",
+        "2025-06",
+        "--sortby",
+        "last_name",
+        "--desc",
+    ])
+    assert args.report_cmd == "show"
+    assert args.month == "2025-06"
+    assert args.sortby == "last_name"
+    assert args.desc is True
+
+
+def test_show_sort_default():
+    from usage_report.cli import parse_args
+
+    args = parse_args(["report", "show", "--month", "2025-06"])
+    assert args.sortby == "gpu_hours"
+
+
+def test_print_usage_table_sort(capsys):
+    from usage_report.cli import print_usage_table
+
+    rows = [
+        {
+            "first_name": "A",
+            "last_name": "",
+            "email": "",
+            "kennung": "a",
+            "projekt": "",
+            "ai_c_group": "",
+            "cpu_hours": 0.0,
+            "gpu_hours": 1.0,
+            "ram_gb_hours": 0.0,
+            "timestamp": "",
+            "period_start": "",
+            "period_end": "",
+        },
+        {
+            "first_name": "B",
+            "last_name": "",
+            "email": "",
+            "kennung": "b",
+            "projekt": "",
+            "ai_c_group": "",
+            "cpu_hours": 0.0,
+            "gpu_hours": 5.0,
+            "ram_gb_hours": 0.0,
+            "timestamp": "",
+            "period_start": "",
+            "period_end": "",
+        },
+    ]
+
+    print_usage_table(rows, sort_key="gpu_hours", reverse=True)
+    out = capsys.readouterr().out.splitlines()
+    first_row = out[2]
+    assert first_row.startswith("B")


### PR DESCRIPTION
## Summary
- rename `--sort-by` option to `--sortby`
- default sort column is `gpu_hours`
- update README usage examples
- update tests for new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664dab77588325a13ffea2f353e451