### PR TITLE
Stop printing group lookup errors

### DIFF
--- a/usage_report/groups.py
+++ b/usage_report/groups.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import subprocess
-import sys
+import logging
 from typing import List
+
+logger = logging.getLogger(__name__)
 
 
 def list_user_groups(user: str) -> List[str]:
@@ -13,9 +15,9 @@ def list_user_groups(user: str) -> List[str]:
         )
     except subprocess.CalledProcessError as exc:
         msg = " ".join(exc.cmd) if isinstance(exc.cmd, list) else str(exc.cmd)
-        print(f"Error running '{msg}': {exc}", file=sys.stderr)
+        logger.debug("Error running '%s': %s", msg, exc)
         if exc.stderr:
-            print(exc.stderr, file=sys.stderr)
+            logger.debug(exc.stderr)
         return []
     output = proc.stdout.strip()
     try:


### PR DESCRIPTION
## Summary
- reduce noise when listing groups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cf82aa60832586442c71de762e74