### PR TITLE
Fix partition filtering in active reports

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -108,7 +108,8 @@ def test_create_active_reports():
             side_effect=reports,
         ) as cr:
             rows = create_active_reports("2025-06-01", "2025-06-30", partitions=["gpu"])
-    fa.assert_called_once_with("2025-06-01", "2025-06-30", partitions=["gpu"])
+    # ``fetch_active_usage`` no longer receives partition filters
+    fa.assert_called_once_with("2025-06-01", "2025-06-30")
     assert cr.call_count == 2
     assert {call.args[0] for call in cr.call_args_list} == {"user1", "user2"}
     assert all("timestamp" in r for r in rows)
@@ -157,6 +158,7 @@ def test_create_active_reports_skip_error():
         ) as cr:
             rows = create_active_reports("2025-06-01", "2025-06-30")
 
-    fa.assert_called_once_with("2025-06-01", "2025-06-30", partitions=None)
+    # fetch_active_usage is called without partition filters
+    fa.assert_called_once_with("2025-06-01", "2025-06-30")
     assert {call.args[0] for call in cr.call_args_list} == {"user1", "bad", "user2"}
     assert {r["kennung"] for r in rows} == {"user1", "user2"}

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -116,7 +116,9 @@ def create_active_reports(
     The list includes a ``timestamp`` as well as ``period_start`` and
     ``period_end`` fields for each user.
     """
-    active = fetch_active_usage(start, end, partitions=partitions)
+    # fetch_active_usage does not support partition filtering via sreport,
+    # so the partitions are only applied when creating individual reports
+    active = fetch_active_usage(start, end)
     user_ids = [u for u in active if u != "partitions"]
     rows: list[dict[str, object]] = []
     for user in user_ids:

--- a/usage_report/sreport.py
+++ b/usage_report/sreport.py
@@ -43,7 +43,8 @@ def fetch_active_usage(
         returned.
     partitions:
         Iterable of partitions to include. Only stored in the result for
-        reference.
+        reference. ``sreport`` does not support filtering by partitions,
+        therefore the argument is ignored when building the command.
     """
     cmd = [
         "sreport",
@@ -53,9 +54,6 @@ def fetch_active_usage(
     ]
     if end:
         cmd.append(f"end={end}")
-    if partitions:
-        for part in partitions:
-            cmd.append(f"partition={part}")
     cmd.append("format=Login,Used")
     proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
     usage = parse_sreport_output(proc.stdout)


### PR DESCRIPTION
## Summary
- remove partition parameters from `fetch_active_usage` call in `create_active_reports`
- document that `fetch_active_usage` ignores partitions and update logic accordingly
- adjust tests to match new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d44020848325b1b651e17607786a