### PR TITLE
Add multi-month aggregation for active usage reports

### DIFF
--- a/usage_report/__init__.py
+++ b/usage_report/__init__.py
@@ -2,7 +2,12 @@
 
 from .api import SimAPI, SimAPIError
 from .slurm import fetch_usage, parse_elapsed, parse_tres, parse_mem
-from .report import create_report, create_active_reports, write_report_csv
+from .report import (
+    create_report,
+    create_active_reports,
+    write_report_csv,
+    aggregate_rows,
+)
 from .sreport import fetch_active_usage, parse_sreport_output
 from .database import store_month, load_month, list_months
 from .groups import list_user_groups
@@ -17,6 +22,7 @@ __all__ = [
     "create_report",
     "create_active_reports",
     "write_report_csv",
+    "aggregate_rows",
     "list_user_groups",
     "fetch_active_usage",
     "parse_sreport_output",


### PR DESCRIPTION
## Summary
- allow comma separated month lists for `report active`
- add optional `--aggregate` flag supporting per-user or per-group aggregation
- implement `aggregate_rows` helper and expose from API
- print partition info in aggregated output
- support custom columns for `print_usage_table`
- test new options and aggregation behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d87397ac83258a8658da2215f52b