### PR TITLE
Fix sorting and partition info for active report aggregates

### DIFF
--- a/usage_report/cli.py
+++ b/usage_report/cli.py
@@ -473,7 +473,12 @@ def main(argv: list[str] | None = None) -> int:
                         "period_start",
                         "period_end",
                     ]
-                    print_usage_table(aggregated, columns=cols)
+                    print_usage_table(
+                        aggregated,
+                        sort_key=args.sortby,
+                        reverse=(args.desc or args.sortby == "gpu_hours"),
+                        columns=cols,
+                    )
                 else:
                     cols = [
                         "first_name",

--- a/usage_report/report.py
+++ b/usage_report/report.py
@@ -233,7 +233,7 @@ def aggregate_rows(
 ) -> list[dict[str, object]]:
     """Return ``rows`` aggregated either by user or by ``ai_c_group``."""
 
-    part_str = ",".join(sorted(partitions or []))
+    part_str = ",".join(sorted(partitions or ["*"]))
     aggr: dict[str, dict[str, object]] = {}
     for row in rows:
         if not isinstance(row, dict):


### PR DESCRIPTION
## Summary
- sort aggregated active reports by the requested column
- show `*` when all partitions are aggregated
- test sorting for grouped aggregates and update partition expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867999724c0832592090379cac56815