### PR TITLE
Support specifying active user groups in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@ usage [--debug] <command> [options]
 usage sim <user_id> [--netrc-file PATH]
 
 # aggregate Slurm usage
-usage slurm <user_id> -S 2025-06-27 [-E 2025-06-30]
+usage slurm <user_id>[,<user_id>...] -S 2025-06-27 [-E 2025-06-30]
 # or entire month
-usage slurm <user_id> --month 2025-06
+usage slurm <user_id>[,<user_id>...] --month 2025-06
 # filter by partition (can be used multiple times, supports wildcards)
-usage slurm <user_id> --month 2025-06 \
+usage slurm <user_id>[,<user_id>...] --month 2025-06 \
     --partition lrz* --partition mcml*
 # quote wildcards to prevent shell expansion if needed
-# usage slurm <user_id> --month 2025-06 \
+# usage slurm <user_id>[,<user_id>...] --month 2025-06 \
 #     --partition 'lrz*' --partition 'mcml*'
 
 # cluster usage for active users
 usage report active -S 2025-06-27 [-E 2025-06-30] [--netrc-file PATH]
+# restrict to a group of users
+usage active --month 2025-06 --user-list user1,user2
 # show stored month with partition column ("*" means all partitions)
 usage report active --month 2025-06 --partition mcml*
 


### PR DESCRIPTION
## Summary
- add a `--user-list` option for the `active` command and normalize the user list
- show per-user usage alongside a combined group total when specific users are requested
- document the new flag and cover it with CLI tests
- allow the `slurm` command to accept multiple user identifiers (comma separated or repeated) and emit per-user usage plus a group aggregate

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b68dd7788325953b1bd690754c98)